### PR TITLE
psutil

### DIFF
--- a/openerp/service/server.py
+++ b/openerp/service/server.py
@@ -52,6 +52,12 @@ except ImportError:
 
 SLEEP_INTERVAL = 60     # 1 min
 
+def memory_info(process):
+    """ psutil < 2.0 does not have memory_info, >= 3.0 does not have
+    get_memory_info """
+    pmem = (getattr(process, 'memory_info', None) or process.get_memory_info)()
+    return (pmem.rss, pmem.vms)
+
 #----------------------------------------------------------
 # Werkzeug WSGI servers patched
 #----------------------------------------------------------


### PR DESCRIPTION
psutil < 2.0 does not have memory_info, >= 3.0 does not have get_memory_info
